### PR TITLE
Use bracket syntax for attributes for Chef 13 compatibility

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@ include_attribute 'delivery-base'
 default['delivery_build']['release-channel'] = 'stable'
 
 # Directories we need for the builder workspace
-default['delivery_build']['root'] = platform_family == 'windows' ? 'C:/delivery/ws' : '/var/opt/delivery/workspace'
+default['delivery_build']['root'] = node["platform_family"] == 'windows' ? 'C:/delivery/ws' : '/var/opt/delivery/workspace'
 
 default['delivery_build']['bin'] = File.join(node['delivery_build']['root'], 'bin')
 default['delivery_build']['lib'] = File.join(node['delivery_build']['root'], 'lib')

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'apache2'
 description 'Sets up a delivery build node'
-version '0.4.26'
+version '0.4.27'
 
 depends 'git'
 depends 'build-essential'


### PR DESCRIPTION
Simply changes a single attribute to be in the "bracket" syntax, so that cookbook does not fail under Chef 13.

Ref: https://docs.chef.io/deprecations_attributes.html#method-access